### PR TITLE
Changed it so only one circle can be locked on to the cursor at a time, ...

### DIFF
--- a/sketches/bannerSketch.pde
+++ b/sketches/bannerSketch.pde
@@ -55,8 +55,8 @@ void setup() {
     e[j][0]=random(width); // X 
     e[j][1]=random(height); // Y
     e[j][2]=random(minSize, maxSize); // Radius        
-    e[j][3]=random(-.5, .5); // X Speed
-    e[j][4]=random(-.5, .5); // Y Speed
+    e[j][3]=random(-.12, .12); // X Speed
+    e[j][4]=random(-.12, .12); // Y Speed
   }
 }
 
@@ -71,16 +71,14 @@ void draw() {
     // Cache diameter and radius of current circle
     float radi=e[j][2];
     float diam=radi/2;
-    if (lockedCircle == j && dragging) {
-      // Change fill color to green.
-      fill(64, 187, 128, 100);
+    if (sq(e[j][0] - mouseX) + sq(e[j][1] - mouseY) < sq(e[j][2]/2))
+      fill(64, 187, 128, 100); // green if mouseover
+    else
+      fill(64, 128, 187, 100); // regular
+    if ((lockedCircle == j && dragging)) {
       // Move the particle's coordinates to the mouse's position, minus its original offset
       e[j][0]=mouseX-lockedOffsetX;
       e[j][1]=mouseY-lockedOffsetY;
-    }
-    else {
-      // Keep fill color blue
-      fill(64, 128, 187, 100);
     }
     // Draw circle
     ellipse(e[j][0], e[j][1], radi, radi);
@@ -105,7 +103,7 @@ void draw() {
     }
 
     // If current circle is selected...
-    if (lockedCircle == j && dragging) {
+    if ((lockedCircle == j && dragging)) {
       // Set fill color of center dot to white..
       fill(255, 255, 255, 255);
       // ..and set stroke color of line to green.


### PR DESCRIPTION
...also the offset is memorized, so it doesn't just snap to the center of the cursor.

For some reason the diameter is used for the distance when seeing which circles to highlight. Whoever did the math seemed to have their radius and diameter mixed up. I did not fix that (will do that later probably, when I have time)

I increased the framerate limit to 60. Because 10 is way too slow and choppy. Hopefully this won't affect webpage performance (it runs at about 210-220 fps on chrome here)

Also, I changed the distance checks (if (sqrt((y1 - y0)^2 + (x1-x0)^2) < radius) to if ((y1 - y0)^2 + (x1-x0)^2 < radius^2), simply for efficiency. One could store radius squared if they wanted, say, a million circles instead of 20 or so.
