### PR TITLE
Fixed links for P5-only functions

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -233,12 +233,12 @@ title: reference
           <a href="/reference/keyReleased_/">keyReleased()</a>
           <a href="/reference/keyTyped_/">keyTyped()</a>
         <h5>Files</h5>
-          <a class="warning" href="http://processing.org/reference/createInput_/" title="Link to native docs">createInput()</a> <!--NOT DONE-->
+          <a class="warning" href="http://processing.org/reference/createInput_.html" title="Link to native docs">createInput()</a> <!--NOT DONE-->
           <a href="/reference/loadBytes_/">loadBytes()</a>
           <a href="/reference/loadStrings_/">loadStrings()</a>
-          <a class="warning" href="http://processing.org/reference/open_/" title="Link to native docs">open()</a><!--NOT DONE-->
-          <a class="warning" href="http://processing.org/reference/selectFolder_/" title="Link to native docs">selectFolder()</a><!--NOT DONE-->
-          <a class="warning" href="http://processing.org/reference/selectInput_/" title="Link to native docs">selectInput()</a><!--NOT DONE-->
+          <a class="warning" href="http://processing.org/reference/open_.html" title="Link to native docs">open()</a><!--NOT DONE-->
+          <a class="warning" href="http://processing.org/reference/selectFolder_.html" title="Link to native docs">selectFolder()</a><!--NOT DONE-->
+          <a class="warning" href="http://processing.org/reference/selectInput_.html" title="Link to native docs">selectInput()</a><!--NOT DONE-->
         <h5>Web</h5>
           <a href="/reference/link_/">link()</a>
           <a class="warning" href="http://processing.org/reference/param_/" title="Link to native docs">param()</a><!--NOT DONE-->
@@ -265,18 +265,18 @@ title: reference
         </div>
         <div class="category">
           <h5>Files</h5>
-            <a href="http://processing.org/reference/PrintWriter/" title="Link to native docs" class="warning">PrintWriter</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/beginRaw_/" title="Link to native docs" class="warning">beginRaw()</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/beginRecord_/" title="Link to native docs" class="warning">beginRecord()</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/createOutput_/" title="Link to native docs" class="warning">createOutput()</a>    <!--NOT DONE-->
-            <a href="http://processing.org/reference/createReader_/" title="Link to native docs" class="warning">createReader()</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/createWriter_/" title="Link to native docs" class="warning">createWriter()</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/endRaw_/" title="Link to native docs" class="warning">endRaw()</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/endRecord_/" title="Link to native docs" class="warning">endRecord()</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/saveBytes_/" title="Link to native docs" class="warning">saveBytes()</a><!--NOT DONE-->
-            <a href="http://processing.org/reference/saveStream_/" title="Link to native docs" class="warning">saveStream()</a> <!--NOT DONE-->
+            <a href="http://processing.org/reference/PrintWriter.html" title="Link to native docs" class="warning">PrintWriter</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/beginRaw_.html" title="Link to native docs" class="warning">beginRaw()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/beginRecord_.html" title="Link to native docs" class="warning">beginRecord()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/createOutput_.html" title="Link to native docs" class="warning">createOutput()</a>    <!--NOT DONE-->
+            <a href="http://processing.org/reference/createReader_.html" title="Link to native docs" class="warning">createReader()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/createWriter_.html" title="Link to native docs" class="warning">createWriter()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/endRaw_.html" title="Link to native docs" class="warning">endRaw()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/endRecord_.html/" title="Link to native docs" class="warning">endRecord()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/saveBytes_.html" title="Link to native docs" class="warning">saveBytes()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/saveStream_.html" title="Link to native docs" class="warning">saveStream()</a> <!--NOT DONE-->
             <a href="/reference/saveStrings_/">saveStrings()</a>
-            <a href="http://processing.org/reference/selectOutput_/" title="Link to native docs" class="warning">selectOutput()</a><!--NOT DONE-->
+            <a href="http://processing.org/reference/selectOutput_.html" title="Link to native docs" class="warning">selectOutput()</a><!--NOT DONE-->
         </div>
       </div>
       <div class="category">


### PR DESCRIPTION
Updated links for functions not implemented in Pjs as main Processing reference pages use `/function_.html` instead of `/function_/`.  Didn't update `param()` because I couldn't find any reference to it (or the other web functions).
