### PR TITLE
Fix typo and link typo in article "Rendering Modes"

### DIFF
--- a/articles/_posts/2011-12-02-RenderingModes.html
+++ b/articles/_posts/2011-12-02-RenderingModes.html
@@ -215,9 +215,9 @@ void draw() {
     different arguments for points in 2D or 3D space). By learning the Processing syntax,
     it's easy to create complex 2D and WebGL graphics without ever touching the underlying
     graphics APIs. This is true of Processing and Java, and also of Processing.js and
-    canvas/WebGL. The Processing langauge provides a powerful and beginner friendly
+    canvas/WebGL. The Processing language provides a powerful and beginner friendly
     on-ramp to canvas 2D and WebGL. Consult the <a href="http://processingjs.org/reference/">
-        Processing.js Langauge Reference</a> for specific details on how to use each
+        Processing.js Language Reference</a> for specific details on how to use each
     function.</p>
 <h4>
     Using the Processing.js API in JavaScript</h4>

--- a/articles/_posts/2011-12-02-RenderingModes.html
+++ b/articles/_posts/2011-12-02-RenderingModes.html
@@ -230,7 +230,7 @@ void draw() {
         href="http://processingjs.org/download">http://processingjs.org/download</a>).
     It is essentially the same as Processing.js, but without the code parser (i.e.,
     you can use the API either way, but the Processing.js API is a somewhat smaller
-    file). See <a href="http://processingjs.org/reference/articles/jsQuickStart.html#javascriptonlyprocessingcode">
+    file). See <a href="http://processingjs.org/articles/jsQuickStart.html#javascriptonlyprocessingcode">
         Writing JavaScript-only Processing.js Code</a> for more details.</p>
 <h4>
     Accessing the Raw Canvas Context - Advanced:</h4>


### PR DESCRIPTION
article: http://processingjs.org/articles/RenderingModes.html

typo: langauge -> language

link typo:
http://processingjs.org/reference/articles/jsQuickStart.html#javascriptonlyprocessingcode
->
http://processingjs.org/articles/jsQuickStart.html#javascriptonlyprocessingcode